### PR TITLE
feat: let random button use search query to narrow search

### DIFF
--- a/components/SearchBar.vue
+++ b/components/SearchBar.vue
@@ -57,7 +57,7 @@
           <div class="syntax-guide-icon link-icon" aria-hidden="true"></div>
           Syntax
         </nuxt-link>
-        <nuxt-link to="/random/" class="hidden md:flex menu-link">
+        <nuxt-link :to="randomLink" class="hidden md:flex menu-link">
           <div class="random-icon link-icon" aria-hidden="true"></div>
           Random
         </nuxt-link>
@@ -88,6 +88,13 @@
 import Vue from "vue";
 import getAllCombos from "@/lib/api/get-all-combos";
 
+type NuxtLinkTo = {
+  path: string;
+  query?: {
+    q?: string | (string | null)[];
+  };
+};
+
 export default Vue.extend({
   props: {
     onHomePage: {
@@ -111,6 +118,15 @@ export default Vue.extend({
         return "text-2xl text-center";
       }
       return "pl-8 -ml-6";
+    },
+    randomLink(): NuxtLinkTo {
+      const link: NuxtLinkTo = { path: "/random/" };
+
+      if (this.query) {
+        link.query = { q: this.query };
+      }
+
+      return link;
     },
   },
   watch: {

--- a/lib/api/random.ts
+++ b/lib/api/random.ts
@@ -1,9 +1,20 @@
-import lookupApi from "./spellbook-api";
+import search from "./search";
+import getAllCombos from "./get-all-combos";
 
 import type { FormattedApiResponse } from "./types";
 
-export default async function random(): Promise<FormattedApiResponse> {
-  const combos = await lookupApi();
+export default async function random(
+  query = ""
+): Promise<FormattedApiResponse> {
+  let combos;
+
+  if (query) {
+    const result = await search(query);
+    combos = result.combos;
+  } else {
+    combos = await getAllCombos();
+  }
+
   const randomIndex = Math.floor(Math.random() * combos.length);
 
   return combos[randomIndex];

--- a/pages/random.vue
+++ b/pages/random.vue
@@ -19,11 +19,21 @@ export default Vue.extend({
   layout: "splash",
 
   async mounted(): Promise<void> {
-    const randomCombo = await random();
-
-    this.$router.replace({
+    let query = this.$route.query.q;
+    if (typeof query !== "string") {
+      query = "";
+    }
+    const randomCombo = await random(query);
+    const router = this.$router;
+    const params: Parameters<typeof router.replace>[0] = {
       path: `/combo/${randomCombo.commanderSpellbookId}/`,
-    });
+    };
+
+    if (query) {
+      params.query = { q: query };
+    }
+
+    router.replace(params);
   },
 });
 </script>

--- a/test/components/SearchBar.spec.ts
+++ b/test/components/SearchBar.spec.ts
@@ -71,13 +71,37 @@ describe("SearchBar", () => {
     expect(links.at(0).props("to")).toBe("/");
     expect(links.at(1).props("to")).toBe("/advanced-search/");
     expect(links.at(2).props("to")).toBe("/syntax-guide/");
-    expect(links.at(3).props("to")).toBe("/random/");
+    expect(links.at(3).props("to")).toEqual({ path: "/random/" });
 
     await wrapper.setProps({
       onHomePage: true,
     });
 
     expect(wrapper.findComponent(NuxtLinkStub).exists()).toBe(false);
+  });
+
+  it("applies q query if applicable to random button", async () => {
+    const NuxtLinkStub = {
+      props: ["to"],
+      template: "<div></div>",
+    };
+    // @ts-ignore
+    wrapperOptions.stubs.NuxtLink = NuxtLinkStub;
+    const wrapper = mount(SearchBar, wrapperOptions);
+
+    const links = wrapper.findAllComponents(NuxtLinkStub);
+    const randomButton = links.at(3);
+
+    expect(randomButton.props("to")).toEqual({ path: "/random/" });
+
+    await wrapper.setData({
+      query: "search",
+    });
+
+    expect(randomButton.props("to")).toEqual({
+      path: "/random/",
+      query: { q: "search" },
+    });
   });
 
   it("toggles link menu when menu button is clicked", async () => {

--- a/test/lib/api/random.test.ts
+++ b/test/lib/api/random.test.ts
@@ -1,24 +1,42 @@
 import random from "@/lib/api/random";
-import lookup from "@/lib/api/spellbook-api";
+import search from "@/lib/api/search";
+import getAllCombos from "@/lib/api/get-all-combos";
 import makeFakeCombo from "@/lib/api/make-fake-combo";
 
 import type { FormattedApiResponse } from "@/lib/api/types";
 
 import { mocked } from "ts-jest/utils";
-jest.mock("@/lib/api/spellbook-api");
+jest.mock("@/lib/api/search");
+jest.mock("@/lib/api/get-all-combos");
 
 describe("random", () => {
   let combos: FormattedApiResponse[];
 
   beforeEach(() => {
     combos = [makeFakeCombo(), makeFakeCombo()];
-    mocked(lookup).mockResolvedValue(combos);
+    mocked(search).mockResolvedValue({
+      errors: [],
+      message: "message",
+      sort: "",
+      order: "",
+      combos,
+    });
+    mocked(getAllCombos).mockResolvedValue(combos);
   });
 
-  it("looks up combos from api", async () => {
+  it("looks up all combos", async () => {
     await random();
 
-    expect(lookup).toBeCalledTimes(1);
+    expect(search).toBeCalledTimes(0);
+    expect(getAllCombos).toBeCalledTimes(1);
+  });
+
+  it("looks up combos from search with a query", async () => {
+    await random("query");
+
+    expect(getAllCombos).toBeCalledTimes(0);
+    expect(search).toBeCalledTimes(1);
+    expect(search).toBeCalledWith("query");
   });
 
   it("returns a random combo", async () => {

--- a/test/pages/random.spec.ts
+++ b/test/pages/random.spec.ts
@@ -5,12 +5,12 @@ import makeFakeCombo from "@/lib/api/make-fake-combo";
 import random from "@/lib/api/random";
 import { mocked } from "ts-jest/utils";
 
-import type { Router } from "../types";
+import type { Route, Router } from "../types";
 
 jest.mock("@/lib/api/random");
 
 describe("RandomPage", () => {
-  let $router: Router;
+  let $route: Route, $router: Router;
 
   beforeEach(() => {
     mocked(random).mockResolvedValue(
@@ -18,6 +18,9 @@ describe("RandomPage", () => {
         commanderSpellbookId: "123",
       })
     );
+    $route = {
+      query: {},
+    };
     $router = {
       push: jest.fn(),
       replace: jest.fn(),
@@ -27,6 +30,7 @@ describe("RandomPage", () => {
   it("redirects to a random combo", async () => {
     shallowMount(RandomPage, {
       mocks: {
+        $route,
         $router,
       },
       stubs: {
@@ -40,6 +44,31 @@ describe("RandomPage", () => {
     expect($router.replace).toBeCalledTimes(1);
     expect($router.replace).toBeCalledWith({
       path: `/combo/123/`,
+    });
+  });
+
+  it("redirects to a random combo with query", async () => {
+    $route.query.q = "search";
+    shallowMount(RandomPage, {
+      mocks: {
+        $route,
+        $router,
+      },
+      stubs: {
+        SplashPage: true,
+      },
+    });
+
+    await flushPromises();
+
+    expect(random).toBeCalledTimes(1);
+    expect(random).toBeCalledWith("search");
+    expect($router.replace).toBeCalledTimes(1);
+    expect($router.replace).toBeCalledWith({
+      path: `/combo/123/`,
+      query: {
+        q: "search",
+      },
     });
   });
 });


### PR DESCRIPTION
Work in progress. Still need to do a few things:

- [ ] decide if putting in a search query should be enough to add the q query param (Scryfall does not do this)
- [ ] add handling for when a random combo has no results (redirect to 404 page?)
- [ ] decide if front page should include query when using random button


closes #144 