### PR TITLE
Update featured combos

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,3 +42,9 @@ $ npm run generate
 ```
 
 For detailed explanation on how things work, check out [Nuxt.js docs](https://nuxtjs.org).
+
+## Updating Featured Combos on Home Page
+
+To update what combos are designated as featured, update the script at [./scripts/download-data/is-featured.ts](./scripts/download-data/is-featured.ts). This will typically be the set codes for whatever the most recent sets are.
+
+In addition, go to the Home page component and update the button text to be relevant for whatever combos are being featured.

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -24,7 +24,7 @@
           Random Combo
         </RandomButton>
         <nuxt-link to="/featured/" class="previwed-combos-button button md:m-1">
-          Strixhaven & C21 Combos
+          MH2 Combos
         </nuxt-link>
       </div>
 

--- a/scripts/download-data/get-scryfall.ts
+++ b/scripts/download-data/get-scryfall.ts
@@ -115,22 +115,20 @@ type RawScryfallResponse = Array<{
     mtgtop8: string;
   };
 }>;
-type ScryfallData = Record<
-  string,
-  {
-    setData: {
-      reprint: boolean;
-      setCode: string;
-    };
-    images: {
-      oracle: string;
-      artCrop: string;
-    };
-    isBanned: boolean;
-    isPreview: boolean;
-    edhrecPermalink: string;
-  }
->;
+export type ScryfallEntry = {
+  setData: {
+    reprint: boolean;
+    setCode: string;
+  };
+  images: {
+    oracle: string;
+    artCrop: string;
+  };
+  isBanned: boolean;
+  isPreview: boolean;
+  edhrecPermalink: string;
+};
+type ScryfallData = Record<string, ScryfallEntry>;
 
 export default async function getScryfallData(): Promise<ScryfallData> {
   log("Fetching Scryfall Bulk Data URI");

--- a/scripts/download-data/index.ts
+++ b/scripts/download-data/index.ts
@@ -2,6 +2,7 @@ import fs from "fs";
 import normalizeCardName from "../../lib/normalize-card-name";
 import log from "../shared/log";
 import getScryfallData from "./get-scryfall";
+import isFeatured from "./is-featured";
 import getEDHRECPrices from "./get-edhrec-prices";
 import getEDHRECComboData from "./get-edhrec-combo-data";
 import getGoogleSheetsComboData from "./get-google-sheets-data";
@@ -68,18 +69,8 @@ Promise.all([
         e: sfData.edhrecPermalink,
       };
 
-      if (!sfData.setData.reprint) {
-        const setCode = sfData.setData.setCode;
-
-        // right now, our "fetured" combo is any combos that
-        // are not reprints that have a set code of
-        // commander 2021 or strixhaven. This will need
-        // to be updated when the next preview season comes
-        // around (mh2). Maybe by then there will be a
-        // way to do this automatically?
-        if (setCode === "c21" || setCode === "stx") {
-          cardData[name].f = 1;
-        }
+      if (isFeatured(sfData)) {
+        cardData[name].f = 1;
       }
 
       if (sfData.isBanned) {

--- a/scripts/download-data/is-featured.ts
+++ b/scripts/download-data/is-featured.ts
@@ -1,0 +1,13 @@
+import type { ScryfallEntry } from "./get-scryfall";
+
+export default function isFeatured(sfData: ScryfallEntry): boolean {
+  if (!sfData.setData.reprint) {
+    return false;
+  }
+
+  const setCode = sfData.setData.setCode;
+
+  // update this logic for whatever set codes we
+  // want to feature on the site
+  return setCode === "c21" || setCode === "stx";
+}

--- a/scripts/download-data/is-featured.ts
+++ b/scripts/download-data/is-featured.ts
@@ -9,5 +9,5 @@ export default function isFeatured(sfData: ScryfallEntry): boolean {
 
   // update this logic for whatever set codes we
   // want to feature on the site
-  return setCode === "c21" || setCode === "stx";
+  return setCode === "mh2";
 }


### PR DESCRIPTION
Updates site to show Modern Horizons 2 combos as the features combos. (none on the site yet)

Merge this when ready to switch from c21 & Strixhaven to MH2.