### PR TITLE
chore: added pluraization helper

### DIFF
--- a/components/search/ComboResults.vue
+++ b/components/search/ComboResults.vue
@@ -91,8 +91,8 @@ export default Vue.extend({
           return "No deck data (EDHREC)";
         }
 
-        return `${combo.numberOfEDHRECDecks} deck${
-          combo.numberOfEDHRECDecks === 1 ? "" : "s"
+        return `${combo.numberOfEDHRECDecks} ${
+          this.$pluralize("deck", combo.numberOfEDHRECDecks)
         } (EDHREC)`;
       }
 

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -170,6 +170,7 @@ export default {
       src: "./plugins/api.ts",
       mode: "client",
     },
+    "~/plugins/helpers.ts",
   ],
 
   // Modules for dev and build (recommended) (https://go.nuxtjs.dev/config-modules)

--- a/pages/combo/_id.vue
+++ b/pages/combo/_id.vue
@@ -286,8 +286,8 @@ export default Vue.extend({
 
       if (this.numberOfDecks > 0) {
         data.push(
-          `In ${this.numberOfDecks} deck${
-            this.numberOfDecks === 1 ? "" : "s"
+          `In ${this.numberOfDecks} ${
+            this.$pluralize("deck", this.numberOfDecks)
           } according to EDHREC.`
         );
       }

--- a/plugins/helpers.ts
+++ b/plugins/helpers.ts
@@ -1,0 +1,9 @@
+const pluralize = (word: String, count: Number, alternative = '') => count === 1 ? word : (alternative || `${word}s`);
+
+export {
+  pluralize,
+};
+
+export default (_: any, inject: Function) => {
+  inject('pluralize', pluralize);
+};

--- a/test/components/search/ComboResults.test.ts
+++ b/test/components/search/ComboResults.test.ts
@@ -2,12 +2,16 @@ import { shallowMount, RouterLinkStub } from "@vue/test-utils";
 import type { MountOptions } from "../../types";
 import ComboResults from "@/components/search/ComboResults.vue";
 import makeFakeCombo from "@/lib/api/make-fake-combo";
+import { pluralize as $pluralize } from "~/plugins/helpers";
 
 describe("ComboResults", () => {
   let options: MountOptions;
 
   beforeEach(() => {
     options = {
+      mocks: {
+        $pluralize,
+      },
       stubs: {
         NuxtLink: RouterLinkStub,
         ColorIdentity: true,

--- a/test/pages/combo/_id.test.ts
+++ b/test/pages/combo/_id.test.ts
@@ -5,6 +5,7 @@ import ComboPage from "@/pages/combo/_id.vue";
 import makeFakeCombo from "@/lib/api/make-fake-combo";
 import findById from "@/lib/api/find-by-id";
 import getExternalCardData from "@/lib/get-external-card-data";
+import { pluralize as $pluralize } from "~/plugins/helpers";
 
 jest.mock("@/lib/api/find-by-id");
 jest.mock("@/lib/get-external-card-data");
@@ -31,6 +32,7 @@ describe("ComboPage", () => {
         };
       },
       mocks: {
+        $pluralize,
         $route,
         $router,
       },

--- a/test/plugins/helpers.test.js
+++ b/test/plugins/helpers.test.js
@@ -1,0 +1,26 @@
+import { pluralize } from "~/plugins/helpers";
+
+describe("helpers", () => {
+  describe("pluralize", () => {
+    it("should be defined", () => {
+      expect(pluralize).toBeInstanceOf(Function);
+      expect(pluralize).toHaveLength(2);
+    });
+
+    it("should not require count", () => {
+      expect(pluralize("catpant")).toBe("catpants");
+    });
+
+    it("should work for singular words", () => {
+      expect(pluralize("catpant", 1)).toBe("catpant");
+    });
+
+    it("should work for plural words", () => {
+      expect(pluralize("catpant", 42)).toBe("catpants");
+    });
+
+    it("should work for irregular words", () => {
+      expect(pluralize("box", 42, "boxes")).toBe("boxes");
+    });
+  });
+});


### PR DESCRIPTION
So I pulled the pluralization into a helper as suggested in #216. However I couldn't find a way to test this natively without "mocking" it out. It seems plugins are registered/used during the test runs so I have to do some hacks to mock out the defined helper. I'm not very familiar with Nuxt so do you know a way around this? I searched and this is the only solution I've found so far.

Thoughts?