### PR TITLE
CI updates: GitHub pages and fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,7 @@ jobs:
 
   deploy:
     # only deploy from the main branch
-    if: github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/main' && github.event_name != 'pull_request' && github.repository_owner == 'Commander-Spellbook'
     concurrency: production_deploy
     runs-on: ubuntu-20.04
     needs: [install, linter, unit-tests, integration-tests]

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -10,7 +10,7 @@ on:
       - "development-docs/**"
 jobs:
   update-gh-pages:
-    name: Generate and upload new GitHub Pages
+    name: Generate and upload new developer documentation to GitHub Pages
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repo

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,4 +1,4 @@
-name: Update GitHub Pages
+name: Deploy developer documentation
 
 on:
   workflow_dispatch:

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -5,6 +5,9 @@ on:
   push:
     branches:
       - main
+    paths:
+      - ".github/workflows/*"
+      - "development-docs/**"
 jobs:
   update-gh-pages:
     name: Generate and upload new GitHub Pages

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,30 @@
+name: Update GitHub Pages
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+jobs:
+  update-gh-pages:
+    name: Generate and upload new GitHub Pages
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Run action
+        uses: ldeluigi/markdown-docs@v0
+        with:
+          src: development-docs/
+          dst: ./gh-pages
+          icon: diamond-stone
+          title: Commander Spellbook
+          primary-color: purple
+          secondary-color: blue
+      - name: Deploy GH Pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./gh-pages

--- a/README.md
+++ b/README.md
@@ -20,4 +20,4 @@ We encourage you to copy this data so it lives on!
 
 ## Development
 
-See [the development docs](./development-docs/) for information.
+See [the development docs](https://commander-spellbook.github.io/website-v2/) for information.

--- a/development-docs/README.md
+++ b/development-docs/README.md
@@ -1,5 +1,7 @@
 # Development Docs
 
+This documentation is rendered as a website on [GitHub Pages](https://commander-spellbook.github.io/website-v2/). Any change to markdown files will be deployed after it gets merged into the `main` branch.
+
 ## Getting Started
 
 The site requires [node v16](https://nodejs.org/en/download/) and npm 8 (which comes installed with node@16) to run locally, since it utilizes [npm workspaces](https://docs.npmjs.com/cli/v8/using-npm/workspaces) to structure the repo.

--- a/development-docs/backend/README.md
+++ b/development-docs/backend/README.md
@@ -1,5 +1,3 @@
-- [Running the app locally](./running-locally.md)
-- [Authentication/User Accounts](./users.md)
-- [Database Collections](./database.md)
-- [API](./api.md)
-- [Manual Deploys](./manual-deploys.md)
+# Development documentation
+
+Here you can find the development artifacts.

--- a/development-docs/backend/README.md
+++ b/development-docs/backend/README.md
@@ -1,3 +1,0 @@
-# Development documentation
-
-Here you can find the development artifacts.

--- a/development-docs/backend/SUMMARY.md
+++ b/development-docs/backend/SUMMARY.md
@@ -1,4 +1,4 @@
-* [Running the app locally](./running*locally.md)
+* [Running the app locally](./running-locally.md)
 * [Authentication/User Accounts](./users.md)
 * [Database Collections](./database.md)
 * [API](./api.md)

--- a/development-docs/backend/SUMMARY.md
+++ b/development-docs/backend/SUMMARY.md
@@ -1,0 +1,5 @@
+* [Running the app locally](./running*locally.md)
+* [Authentication/User Accounts](./users.md)
+* [Database Collections](./database.md)
+* [API](./api.md)
+* [Manual Deploys](./manual-deploys.md)

--- a/development-docs/backend/database-refactor.md
+++ b/development-docs/backend/database-refactor.md
@@ -1,0 +1,1 @@
+# Database Refactor

--- a/development-docs/backend/database-refactor.md
+++ b/development-docs/backend/database-refactor.md
@@ -1,1 +1,0 @@
-# Database Refactor

--- a/development-docs/frontend/README.md
+++ b/development-docs/frontend/README.md
@@ -1,3 +1,0 @@
-- [Installation and setup](./installation-and-setup.md)
-- [Creating a new page](./pages.md)
-- [Creating a component](./components.md)

--- a/development-docs/frontend/SUMMARY.md
+++ b/development-docs/frontend/SUMMARY.md
@@ -1,0 +1,3 @@
+* [Installation and setup](./installation-and-setup.md)
+* [Creating a new page](./pages.md)
+* [Creating a component](./components.md)


### PR DESCRIPTION
# Changelog

## Main CI
* Added a filter that runs the deploy step only outside forks and PRs

## The new "Pages" workflow
* This workflow adds automation on generation of an HTML website that displays the `development-docs` markdown content. The generate website si pushed and kept updated in the `gh-pages` branch, from which it can be deployed with GitHub Pages for free.

Side note: the `SUMMARY.md` file contains what is displayed in the navigation menu of that subfolder and in which order. In order to add new files they must be listed in it.

Side note 2: for more information about the Markdown syntax and feature supported see https://ldeluigi.github.io/markdown-docs/