### PR TITLE
feat: added script to run tests in watch mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "firebase:deploy:prod": "firebase deploy --project commander-spellbook-prod",
     "start": "npm start --workspace=frontend",
     "lint": "eslint --ext .ts,.js scripts cypress && npm run lint --workspaces --if-present",
-    "test": "npm t --workspaces --if-present",
+    "test": "npm test --workspaces --if-present",
+    "test:watch-frontend": "npm test --workspace frontend -- --watch --collectCoverage=false",
     "cy:run": "cypress run",
     "pretest:integration": "NODE_ENV=development USE_FIREBASE_EMULATORS=true npm run firebase:emulate & wait-on http://localhost:4000 && npm run build-frontend-for-cypress",
     "test:integration": "npm start & wait-on http://localhost:3000 && npm run cy:run"


### PR DESCRIPTION
Simplifies running tests in watch mode.

## Usage

```shell
npm run test:watch-frontend decklist-parser
```